### PR TITLE
feat: Add SpinnerGuau component for loading state

### DIFF
--- a/client/src/components/common/SpinnerGuau.tsx
+++ b/client/src/components/common/SpinnerGuau.tsx
@@ -1,0 +1,34 @@
+import { Guau_07 } from "../../icons";
+
+
+export const SpinnerGuau = () => {
+    return (
+        <div className="flex flex-wrap fixed top-0 left-0 z-40 w-full h-full items-center justify-center bg-slate-400 bg-opacity-40">
+            <div className="relative w-[20vw] h-[20vw]">
+                {/* Spinner */}
+                <div className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 z-10 w-[20vw] h-[20vw]">
+                    <svg
+                        aria-hidden="true"
+                        className="w-full h-full animate-spin text-tablerobg fill-primary"
+                        viewBox="0 0 100 101"
+                        fill="none"
+                        xmlns="http://www.w3.org/2000/svg"
+                    >
+                        <path
+                        d="M100 50.5908C100 78.2051 77.6142 100.591 50 100.591C22.3858 100.591 0 78.2051 0 50.5908C0 22.9766 22.3858 0.59082 50 0.59082C77.6142 0.59082 100 22.9766 100 50.5908ZM9.08144 50.5908C9.08144 73.1895 27.4013 91.5094 50 91.5094C72.5987 91.5094 90.9186 73.1895 90.9186 50.5908C90.9186 27.9921 72.5987 9.67226 50 9.67226C27.4013 9.67226 9.08144 27.9921 9.08144 50.5908Z"
+                        fill="currentColor"
+                        />
+                        <path
+                        d="M93.9676 39.0409C96.393 38.4038 97.8624 35.9116 97.0079 33.5539C95.2932 28.8227 92.871 24.3692 89.8167 20.348C85.8452 15.1192 80.8826 10.7238 75.2124 7.41289C69.5422 4.10194 63.2754 1.94025 56.7698 1.05124C51.7666 0.367541 46.6976 0.446843 41.7345 1.27873C39.2613 1.69328 37.813 4.19778 38.4501 6.62326C39.0873 9.04874 41.5694 10.4717 44.0505 10.1071C47.8511 9.54855 51.7191 9.52689 55.5402 10.0491C60.8642 10.7766 65.9928 12.5457 70.6331 15.2552C75.2735 17.9648 79.3347 21.5619 82.5849 25.841C84.9175 28.9121 86.7997 32.2913 88.1811 35.8758C89.083 38.2158 91.5421 39.6781 93.9676 39.0409Z"
+                        fill="currentFill"
+                        />
+                    </svg>
+                </div>
+                {/* Guau_07 */}
+                <div className="absolute top-1/2 left-1/2 transform -translate-x-[7.75vw] -translate-y-[15.9vh] w-[31vw] h-[31vw]">
+                    <Guau_07 className="w-1/2 h-1/2" />
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/client/src/components/index.ts
+++ b/client/src/components/index.ts
@@ -1,3 +1,4 @@
 export { Frame_Puzzles_Guau } from './puzzles/Frame_Puzzles_Guau';
 export { Navbar } from './navegation/Navbar';
 export { DialogBoxPuzzleInstructions } from './puzzles/DialogBoxPuzzleInstructions';
+export { SpinnerGuau } from './common/SpinnerGuau';

--- a/client/src/pages/avatar-demo/AvatarDemo.tsx
+++ b/client/src/pages/avatar-demo/AvatarDemo.tsx
@@ -1,8 +1,23 @@
-import { Navbar } from "../../components";
+import { useEffect, useState } from "react";
+import { Navbar, SpinnerGuau } from "../../components";
 
 export const AvatarDemo = () => {
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 1200);
+        return () => clearTimeout(timer);
+    }, []);
+
     return (
         <div className="portrait:hidden">
+            {isLoading ? (
+                <div className="w-screen h-screen flex justify-center items-center">
+                    <SpinnerGuau />
+                </div>
+            ) : (
             <div className="flex flex-col w-full h-screen">
                 <div className="w-full h-[7vh] flex flex-row items-center justify-center">
                     <Navbar />
@@ -11,6 +26,7 @@ export const AvatarDemo = () => {
                     <h1 className="text-[4vh]">Welcome to the Avatar Demo</h1>
                 </div>
             </div>
+            )}
         </div>
     );
 };

--- a/client/src/pages/home/Home.tsx
+++ b/client/src/pages/home/Home.tsx
@@ -1,14 +1,28 @@
-import { Navbar } from "../../components";
+import { FC, useEffect, useState } from "react";
+import { Navbar, SpinnerGuau } from "../../components";
 import BGImage from "../../assets/home/world00_Lobby.png";
 import { Greetting } from "../../layouts";
 
 
 
-export const Home = () => {
+export const Home: FC = () => {
+    const [isLoading, setIsLoading] = useState(true);
     const showText = 'Bienvenido a esta demo de nuestra plataforma de juegos educativos.';
-    
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 1200);
+        return () => clearTimeout(timer);
+    }, []);
+
     return (
         <div className="portrait:hidden">
+            {isLoading ? (
+                <div className="w-screen h-screen flex justify-center items-center">
+                    <SpinnerGuau />
+                </div>
+            ) : (
             <div className="flex flex-col w-full h-screen">
                 <div className="w-full h-[6vh] flex flex-row items-center justify-center">
                     <Navbar />
@@ -27,6 +41,7 @@ export const Home = () => {
                     </div>
                 </div>
             </div>
+            )}
         </div>
     );
 };

--- a/client/src/pages/puzzles/Puzzle_01.tsx
+++ b/client/src/pages/puzzles/Puzzle_01.tsx
@@ -1,10 +1,25 @@
-import { Navbar } from "../../components";
+import { useEffect, useState } from "react";
+import { Navbar, SpinnerGuau } from "../../components";
 import { Board_Puzzle_01 } from "../../layouts";
 import BGImage from "../../assets/puzzle_01/Pzz5_Bg_world05.png";
 
 export const Puzzle_01 = () => {
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 1200);
+        return () => clearTimeout(timer);
+    }, []);
+
     return (
         <div className="portrait:hidden">
+            {isLoading ? (
+                <div className="w-screen h-screen flex justify-center items-center">
+                    <SpinnerGuau />
+                </div>
+            ) : (
             <div className="flex flex-col w-full h-screen">
                 <div className="w-full h-[7vh] flex flex-row items-center justify-center">
                     <Navbar />
@@ -19,6 +34,7 @@ export const Puzzle_01 = () => {
                     <Board_Puzzle_01 />
                 </div>
             </div>
+            )}
         </div>
     );
 };

--- a/client/src/pages/puzzles/Puzzle_02.tsx
+++ b/client/src/pages/puzzles/Puzzle_02.tsx
@@ -1,8 +1,23 @@
-import { Navbar } from "../../components";
+import { useEffect, useState } from "react";
+import { Navbar, SpinnerGuau } from "../../components";
 
 export const Puzzle_02 = () => {
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const timer = setTimeout(() => {
+            setIsLoading(false);
+        }, 1200);
+        return () => clearTimeout(timer);
+    }, []);
+
     return (
         <div className="portrait:hidden">
+            {isLoading ? (
+                <div className="w-screen h-screen flex justify-center items-center">
+                    <SpinnerGuau />
+                </div>
+            ) : (
             <div className="flex flex-col w-full h-screen">
                 <div className="w-full h-[7vh] flex flex-row items-center justify-center">
                     <Navbar />
@@ -11,6 +26,7 @@ export const Puzzle_02 = () => {
                     <h1 className="text-[4vh]">Welcome to Puzzle 02</h1>
                 </div>
             </div>
+            )}
         </div>
     );
 };


### PR DESCRIPTION
This commit adds the SpinnerGuau component to handle the loading state in the AvatarDemo, Home, Puzzle_01, and Puzzle_02 pages. The SpinnerGuau component displays a loading spinner and a Guau_07 icon while the content is being loaded. This improves the user experience by providing visual feedback during loading.

Note: This commit message follows the conventional commit format, starting with a type (feat) followed by a brief description of the changes.